### PR TITLE
Allow CardAction expansion

### DIFF
--- a/dominion/src/dominion/arena/effect.rs
+++ b/dominion/src/dominion/arena/effect.rs
@@ -36,11 +36,21 @@ impl std::fmt::Debug for Effect {
 impl PartialEq for Effect {
     fn eq(&self, other: &Self) -> bool {
         use Effect::*;
+        // In the first two match arms, f1 and f2 are function pointer _references_.
+        // e.g. &for<'r, 's> fn(
+        //          &'r mut dominion::arena::Arena,
+        //          usize,
+        //          &'s [dominion::card::CardKind],
+        //      ) -> std::result::Result<
+        //          dominion::arena::effect::Outcome,
+        //          dominion::types::Error,
+        //      >;
+        // To compare equality, we dereference and then cast the result to a regular pointer.
         match (self, other) {
             (Conditional(f1, s1), Conditional(f2, s2)) => {
-                (f1 as *const _ == f2 as *const _) && (s1 == s2)
+                (*f1 as *const () == *f2 as *const ()) && (s1 == s2)
             }
-            (Unconditional(f1), Unconditional(f2)) => f1 as *const _ == f2 as *const _,
+            (Unconditional(f1), Unconditional(f2)) => *f1 as *const () == *f2 as *const (),
             _ => false,
         }
     }

--- a/dominion/src/dominion/arena/effect.rs
+++ b/dominion/src/dominion/arena/effect.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 // Each card effect is defined in it's own file.
 mod cellar;
 mod chapel;
+mod harbinger;
 mod militia;
 mod throne_room;
 
@@ -48,25 +49,17 @@ impl CardAction {
         let mut effects = Vec::new();
 
         match card {
-            CardKind::Cellar => {
-                effects.push(cellar::EFFECT);
-            }
-            CardKind::Chapel => {
-                effects.push(chapel::EFFECT);
-            }
-            //CardKind::Harbinger => unimplemeted!(),
+            CardKind::Cellar => effects.push(cellar::EFFECT),
+            CardKind::Chapel => effects.push(chapel::EFFECT),
+            CardKind::Harbinger => effects.push(harbinger::EFFECT),
             //CardKind::Vassal => unimplemeted!(),
             //CardKind::Workshop => unimplemeted!(),
             //CardKind::Bureaucrat => unimplemeted!(),
-            CardKind::Militia => {
-                effects.push(militia::EFFECT);
-            }
+            CardKind::Militia => effects.push(militia::EFFECT),
             //CardKind::Moneylender => unimplemeted!(),
             //CardKind::Poacher => unimplemeted!(),
             //CardKind::Remodel => unimplemeted!(),
-            CardKind::ThroneRoom => {
-                effects.push(throne_room::EFFECT);
-            }
+            CardKind::ThroneRoom => effects.push(throne_room::EFFECT),
             //CardKind::Bandit => unimplemeted!(),
             //CardKind::CouncilRoom => unimplemeted!(),
             //CardKind::Festival => unimplemeted!(),
@@ -136,9 +129,11 @@ impl CardActionQueue {
     }
 
     fn from_card(card: CardKind) -> Self {
-        let mut actions = VecDeque::new();
-        actions.push_back(CardAction::new(card));
-        Self { actions }
+        let mut actions = Self::new();
+
+        actions.add_card(card);
+
+        actions
     }
 
     pub(super) fn add_card(&mut self, card: CardKind) {

--- a/dominion/src/dominion/arena/effect.rs
+++ b/dominion/src/dominion/arena/effect.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 
 // Each card effect is defined in it's own file.
 mod cellar;
+mod chapel;
 mod militia;
 mod throne_room;
 
@@ -50,7 +51,9 @@ impl CardAction {
             CardKind::Cellar => {
                 effects.push(cellar::EFFECT);
             }
-            //CardKind::Chapel => unimplemeted!(),
+            CardKind::Chapel => {
+                effects.push(chapel::EFFECT);
+            }
             //CardKind::Harbinger => unimplemeted!(),
             //CardKind::Vassal => unimplemeted!(),
             //CardKind::Workshop => unimplemeted!(),

--- a/dominion/src/dominion/arena/effect.rs
+++ b/dominion/src/dominion/arena/effect.rs
@@ -114,12 +114,12 @@ impl CardAction {
 }
 
 #[derive(Debug)]
-pub(crate) struct CardActionQueue {
+pub(super) struct CardActionQueue {
     actions: VecDeque<CardAction>,
 }
 
 impl CardActionQueue {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             actions: VecDeque::new(),
         }
@@ -131,7 +131,7 @@ impl CardActionQueue {
         Self { actions }
     }
 
-    pub(crate) fn add_card(&mut self, card: CardKind) {
+    pub(super) fn add_card(&mut self, card: CardKind) {
         self.actions.push_back(CardAction::new(card));
     }
 
@@ -139,15 +139,15 @@ impl CardActionQueue {
         self.actions.append(&mut other.actions);
     }
 
-    pub(crate) fn is_resolved(&self) -> bool {
+    pub(super) fn is_resolved(&self) -> bool {
         self.actions.is_empty()
     }
 
-    pub(crate) fn resolve_condition(&self) -> Option<&'static str> {
+    pub(super) fn resolve_condition(&self) -> Option<&'static str> {
         self.actions.iter().find_map(CardAction::condition)
     }
 
-    pub(crate) fn resolve(
+    pub(super) fn resolve(
         &mut self,
         arena: &mut Arena,
         player_id: usize,

--- a/dominion/src/dominion/arena/effect.rs
+++ b/dominion/src/dominion/arena/effect.rs
@@ -3,6 +3,7 @@ use crate::dominion::{Arena, CardKind};
 use std::collections::VecDeque;
 
 // Each card effect is defined in it's own file.
+mod cellar;
 mod militia;
 mod throne_room;
 
@@ -46,7 +47,9 @@ impl CardAction {
         let mut effects = Vec::new();
 
         match card {
-            //CardKind::Cellar => unimplemeted!(),
+            CardKind::Cellar => {
+                effects.push(cellar::EFFECT);
+            }
             //CardKind::Chapel => unimplemeted!(),
             //CardKind::Harbinger => unimplemeted!(),
             //CardKind::Vassal => unimplemeted!(),

--- a/dominion/src/dominion/arena/effect/cellar.rs
+++ b/dominion/src/dominion/arena/effect/cellar.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{Effect, EffectResult};
-use crate::dominion::types::Error;
+use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "Discard any number of cards, then draw that many.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -33,5 +33,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult
         player.draw_card();
     }
 
-    Ok(None)
+    Ok(EffectOutput::None)
 }

--- a/dominion/src/dominion/arena/effect/cellar.rs
+++ b/dominion/src/dominion/arena/effect/cellar.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::arena::effect::{Effect, Outcome};
 use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "Discard any number of cards, then draw that many.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -33,5 +33,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
         player.draw_card();
     }
 
-    Ok(EffectOutput::None)
+    Ok(Outcome::None)
 }

--- a/dominion/src/dominion/arena/effect/cellar.rs
+++ b/dominion/src/dominion/arena/effect/cellar.rs
@@ -1,0 +1,37 @@
+use crate::dominion::arena::effect::{Effect, EffectResult};
+use crate::dominion::types::Error;
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect =
+    &Effect::Conditional(func, "Discard any number of cards, then draw that many.");
+
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    if player_id != arena.current_player_id {
+        return error;
+    }
+
+    let mut hand = &mut arena.current_player().hand.clone();
+
+    if cards.len() <= hand.len() {
+        for card in cards {
+            if hand.remove_item(card).is_none() {
+                return error;
+            }
+        }
+    } else {
+        return error;
+    }
+
+    let player = arena.current_player_mut();
+    std::mem::swap(&mut player.hand, &mut hand);
+    for &card in cards {
+        player.discard_pile.push(card);
+    }
+    for _ in cards {
+        player.draw_card();
+    }
+
+    Ok(None)
+}

--- a/dominion/src/dominion/arena/effect/chapel.rs
+++ b/dominion/src/dominion/arena/effect/chapel.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{Effect, EffectResult};
-use crate::dominion::types::Error;
+use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "Trash up to 4 cards from your hand.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -34,5 +34,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult
         arena.trash.push(card);
     }
 
-    Ok(None)
+    Ok(EffectOutput::None)
 }

--- a/dominion/src/dominion/arena/effect/chapel.rs
+++ b/dominion/src/dominion/arena/effect/chapel.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::arena::effect::{Effect, Outcome};
 use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "Trash up to 4 cards from your hand.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -34,5 +34,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
         arena.trash.push(card);
     }
 
-    Ok(EffectOutput::None)
+    Ok(Outcome::None)
 }

--- a/dominion/src/dominion/arena/effect/chapel.rs
+++ b/dominion/src/dominion/arena/effect/chapel.rs
@@ -28,11 +28,94 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outco
         return error;
     }
 
-    let player = arena.current_player_mut();
-    std::mem::swap(&mut player.hand, &mut hand);
+    std::mem::swap(&mut arena.current_player_mut().hand, &mut hand);
     for &card in cards {
         arena.trash.push(card);
     }
 
     Ok(Outcome::None)
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::test_util;
+    use super::*;
+    use crate::dominion::types::Error;
+    use crate::dominion::CardKind;
+
+    #[test]
+    fn trash_0_cards() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let hand_size = arena.current_player().hand.len();
+        let cards = [];
+
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+        assert_eq!(arena.current_player().hand.len(), hand_size);
+        assert_eq!(arena.trash.len(), cards.len());
+    }
+
+    #[test]
+    fn trash_1_card() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let hand = &arena.current_player().hand;
+        let hand_size = hand.len();
+        let cards = [hand[0]];
+
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+        assert_eq!(arena.current_player().hand.len(), hand_size - cards.len());
+        assert_eq!(arena.trash.len(), cards.len());
+    }
+
+    #[test]
+    fn trash_card_not_in_hand() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let hand = &arena.current_player().hand;
+        let hand_size = hand.len();
+        let cards = [CardKind::Gold];
+
+        assert!(!hand.contains(&cards[0]));
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+        assert_eq!(arena.current_player().hand.len(), hand_size);
+        assert_eq!(arena.trash.len(), 0);
+    }
+
+    #[test]
+    fn trash_4_cards() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let hand = &arena.current_player().hand;
+        let hand_size = hand.len();
+        let cards = [hand[0], hand[1], hand[2], hand[3]];
+
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+        assert_eq!(arena.current_player().hand.len(), hand_size - cards.len());
+        assert_eq!(arena.trash.len(), cards.len());
+    }
+
+    #[test]
+    fn trash_5_cards() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let hand = &arena.current_player().hand;
+        let hand_size = hand.len();
+        let cards = [hand[0], hand[1], hand[2], hand[3], hand[4]];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+        assert_eq!(arena.current_player().hand.len(), hand_size);
+        assert_eq!(arena.trash.len(), 0);
+    }
 }

--- a/dominion/src/dominion/arena/effect/chapel.rs
+++ b/dominion/src/dominion/arena/effect/chapel.rs
@@ -1,0 +1,38 @@
+use crate::dominion::arena::effect::{Effect, EffectResult};
+use crate::dominion::types::Error;
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect =
+    &Effect::Conditional(func, "Trash up to 4 cards from your hand.");
+
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    if player_id != arena.current_player_id {
+        return error;
+    }
+
+    let mut hand = &mut arena.current_player().hand.clone();
+
+    if cards.len() <= hand.len() {
+        if cards.len() > 4 {
+            return error;
+        }
+
+        for card in cards {
+            if hand.remove_item(card).is_none() {
+                return error;
+            }
+        }
+    } else {
+        return error;
+    }
+
+    let player = arena.current_player_mut();
+    std::mem::swap(&mut player.hand, &mut hand);
+    for &card in cards {
+        arena.trash.push(card);
+    }
+
+    Ok(None)
+}

--- a/dominion/src/dominion/arena/effect/harbinger.rs
+++ b/dominion/src/dominion/arena/effect/harbinger.rs
@@ -1,0 +1,46 @@
+use crate::dominion::arena::effect::{Effect, EffectResult};
+use crate::dominion::types::{CardSpecifier, Error, Location};
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect = &Effect::Conditional(
+    func,
+    "Look through your discard pile. You may put a card from it onto your deck.",
+);
+
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    if player_id != arena.current_player_id {
+        return error;
+    }
+
+    let card_index;
+
+    if cards.is_empty() {
+        card_index = None;
+    } else if cards.len() == 1 {
+        match arena
+            .current_player()
+            .discard_pile
+            .iter()
+            .position(|&card| card == cards[0])
+        {
+            Some(i) => card_index = Some(CardSpecifier::Index(i)),
+            None => return error,
+        }
+    } else {
+        return error;
+    }
+
+    if let Some(card_index) = card_index {
+        arena
+            .move_card(
+                Location::Discard { player_id },
+                Location::Draw { player_id },
+                card_index,
+            )
+            .unwrap();
+    }
+
+    Ok(None)
+}

--- a/dominion/src/dominion/arena/effect/harbinger.rs
+++ b/dominion/src/dominion/arena/effect/harbinger.rs
@@ -44,3 +44,66 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outco
 
     Ok(Outcome::None)
 }
+
+#[cfg(test)]
+mod test {
+    use super::super::test_util;
+    use super::*;
+    use crate::dominion::types::Error;
+    use crate::dominion::CardKind;
+
+    #[test]
+    fn empty_discard_pile() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let cards = [];
+
+        assert!(arena.current_player().discard_pile.is_empty());
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+    }
+
+    #[test]
+    fn choose_not_to_move_card() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let cards = [];
+
+        arena.current_player_mut().discard_pile.push(CardKind::Gold);
+
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+    }
+
+    #[test]
+    fn choose_to_move_card() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let cards = [CardKind::Gold];
+
+        arena.current_player_mut().discard_pile.push(cards[0]);
+
+        assert_ne!(arena.current_player().draw_pile.last().unwrap(), &cards[0]);
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
+        assert_eq!(arena.current_player().draw_pile.last().unwrap(), &cards[0]);
+        assert!(arena.current_player().discard_pile.is_empty());
+    }
+
+    #[test]
+    fn choose_card_not_in_discard_pile() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.current_player_id;
+
+        let cards = [CardKind::Silver];
+
+        arena.current_player_mut().discard_pile.push(CardKind::Gold);
+
+        assert!(!arena.current_player().discard_pile.contains(&cards[0]));
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+        assert_eq!(arena.current_player().discard_pile.len(), 1);
+    }
+}

--- a/dominion/src/dominion/arena/effect/harbinger.rs
+++ b/dominion/src/dominion/arena/effect/harbinger.rs
@@ -1,5 +1,5 @@
-use crate::dominion::arena::effect::{Effect, EffectResult};
-use crate::dominion::types::{CardSpecifier, Error, Location};
+use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::types::{CardSpecifier, Error, Location, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect = &Effect::Conditional(
@@ -7,7 +7,7 @@ pub(super) const EFFECT: &Effect = &Effect::Conditional(
     "Look through your discard pile. You may put a card from it onto your deck.",
 );
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -42,5 +42,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult
             .unwrap();
     }
 
-    Ok(None)
+    Ok(EffectOutput::None)
 }

--- a/dominion/src/dominion/arena/effect/harbinger.rs
+++ b/dominion/src/dominion/arena/effect/harbinger.rs
@@ -1,4 +1,4 @@
-use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::arena::effect::{Effect, Outcome};
 use crate::dominion::types::{CardSpecifier, Error, Location, Result};
 use crate::dominion::{Arena, CardKind};
 
@@ -7,7 +7,7 @@ pub(super) const EFFECT: &Effect = &Effect::Conditional(
     "Look through your discard pile. You may put a card from it onto your deck.",
 );
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -42,5 +42,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
             .unwrap();
     }
 
-    Ok(EffectOutput::None)
+    Ok(Outcome::None)
 }

--- a/dominion/src/dominion/arena/effect/militia.rs
+++ b/dominion/src/dominion/arena/effect/militia.rs
@@ -1,5 +1,5 @@
-use crate::dominion::arena::effect::{Effect, EffectResult};
-use crate::dominion::types::Error;
+use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect = &Effect::Conditional(
@@ -7,7 +7,7 @@ pub(super) const EFFECT: &Effect = &Effect::Conditional(
     "Each other player discards down to 3 cards in their hand.",
 );
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     // TODO: Handle games with more than 2 players.
@@ -37,5 +37,5 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult
         player.discard_pile.push(card);
     }
 
-    Ok(None)
+    Ok(EffectOutput::None)
 }

--- a/dominion/src/dominion/arena/effect/militia.rs
+++ b/dominion/src/dominion/arena/effect/militia.rs
@@ -39,3 +39,175 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
 
     Ok(EffectOutput::None)
 }
+
+#[cfg(test)]
+mod test {
+    use super::super::test_util;
+    use super::*;
+    use crate::dominion::types::Error;
+    use crate::dominion::CardKind;
+
+    #[test]
+    fn other_player_0_cards_in_hand_discard_0() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        arena.player_mut(player_id).unwrap().hand.clear();
+        let cards = [];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_1_card_in_hand_discard_0() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        while arena.player(player_id).unwrap().hand.len() > 1 {
+            arena.player_mut(player_id).unwrap().hand.pop();
+        }
+        let cards = [];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_2_cards_in_hand_discard_0() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        while arena.player(player_id).unwrap().hand.len() > 2 {
+            arena.player_mut(player_id).unwrap().hand.pop();
+        }
+        let cards = [];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_3_cards_in_hand_discard_0() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        while arena.player(player_id).unwrap().hand.len() > 3 {
+            arena.player_mut(player_id).unwrap().hand.pop();
+        }
+        let cards = [];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_4_cards_in_hand_discard_1() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        while arena.player(player_id).unwrap().hand.len() > 4 {
+            arena.player_mut(player_id).unwrap().hand.pop();
+        }
+        let cards = [arena.player(player_id).unwrap().hand[0]];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_4_cards_in_hand_discard_2() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        while arena.player(player_id).unwrap().hand.len() > 4 {
+            arena.player_mut(player_id).unwrap().hand.pop();
+        }
+        let cards = [
+            arena.player(player_id).unwrap().hand[0],
+            arena.player(player_id).unwrap().hand[1],
+        ];
+
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+    }
+
+    #[test]
+    fn other_player_5_cards_in_hand_discard_2() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        let cards = [
+            arena.player(player_id).unwrap().hand[0],
+            arena.player(player_id).unwrap().hand[1],
+        ];
+
+        assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Ok(EffectOutput::None)
+        );
+    }
+
+    #[test]
+    fn other_player_cards_not_in_hand() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        let hand = &mut arena.player_mut(player_id).unwrap().hand;
+        hand.clear();
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+
+        let cards = [
+            CardKind::Silver,
+            CardKind::Silver,
+        ];
+
+        assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+    }
+
+    #[test]
+    fn other_player_not_enough_copies_in_hand() {
+        let mut arena = test_util::setup_arena();
+        let player_id = arena.next_player_id();
+
+        let hand = &mut arena.player_mut(player_id).unwrap().hand;
+        hand.clear();
+        hand.push(CardKind::Silver);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+        hand.push(CardKind::Copper);
+
+        let cards = [
+            CardKind::Silver,
+            CardKind::Silver,
+        ];
+
+        assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
+        assert_eq!(
+            func(&mut arena, player_id, &cards),
+            Err(Error::UnresolvedActionEffect(EFFECT.description()))
+        );
+    }
+}

--- a/dominion/src/dominion/arena/effect/militia.rs
+++ b/dominion/src/dominion/arena/effect/militia.rs
@@ -1,0 +1,41 @@
+use crate::dominion::arena::effect::{Effect, EffectResult};
+use crate::dominion::types::Error;
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect = &Effect::Conditional(
+    func,
+    "Each other player discards down to 3 cards in their hand.",
+);
+
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    // TODO: Handle games with more than 2 players.
+    if player_id == arena.current_player_id {
+        return error;
+    }
+
+    let mut hand = &mut arena.player(player_id).unwrap().hand.clone();
+
+    if hand.len() <= 3 {
+        if !cards.is_empty() {
+            return error;
+        }
+    } else if hand.len() == cards.len() + 3 {
+        for card in cards {
+            if hand.remove_item(card).is_none() {
+                return error;
+            }
+        }
+    } else {
+        return error;
+    }
+
+    let player = arena.player_mut(player_id).unwrap();
+    std::mem::swap(&mut player.hand, &mut hand);
+    for &card in cards {
+        player.discard_pile.push(card);
+    }
+
+    Ok(None)
+}

--- a/dominion/src/dominion/arena/effect/militia.rs
+++ b/dominion/src/dominion/arena/effect/militia.rs
@@ -1,4 +1,4 @@
-use crate::dominion::arena::effect::{Effect, EffectOutput};
+use crate::dominion::arena::effect::{Effect, Outcome};
 use crate::dominion::types::{Error, Result};
 use crate::dominion::{Arena, CardKind};
 
@@ -7,7 +7,7 @@ pub(super) const EFFECT: &Effect = &Effect::Conditional(
     "Each other player discards down to 3 cards in their hand.",
 );
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     // TODO: Handle games with more than 2 players.
@@ -37,7 +37,7 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
         player.discard_pile.push(card);
     }
 
-    Ok(EffectOutput::None)
+    Ok(Outcome::None)
 }
 
 #[cfg(test)]
@@ -55,10 +55,7 @@ mod test {
         arena.player_mut(player_id).unwrap().hand.clear();
         let cards = [];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -71,10 +68,7 @@ mod test {
         }
         let cards = [];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -87,10 +81,7 @@ mod test {
         }
         let cards = [];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -103,10 +94,7 @@ mod test {
         }
         let cards = [];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -119,10 +107,7 @@ mod test {
         }
         let cards = [arena.player(player_id).unwrap().hand[0]];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -155,10 +140,7 @@ mod test {
         ];
 
         assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -174,10 +156,7 @@ mod test {
         hand.push(CardKind::Copper);
         hand.push(CardKind::Copper);
 
-        let cards = [
-            CardKind::Silver,
-            CardKind::Silver,
-        ];
+        let cards = [CardKind::Silver, CardKind::Silver];
 
         assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
         assert_eq!(
@@ -199,10 +178,7 @@ mod test {
         hand.push(CardKind::Copper);
         hand.push(CardKind::Copper);
 
-        let cards = [
-            CardKind::Silver,
-            CardKind::Silver,
-        ];
+        let cards = [CardKind::Silver, CardKind::Silver];
 
         assert_eq!(arena.player(player_id).unwrap().hand.len(), 5);
         assert_eq!(

--- a/dominion/src/dominion/arena/effect/test_util.rs
+++ b/dominion/src/dominion/arena/effect/test_util.rs
@@ -1,0 +1,14 @@
+use crate::dominion::arena::effect::CardActionQueue;
+use crate::dominion::{Arena, KingdomSet};
+
+#[cfg(test)]
+pub(super) fn setup_arena_actions() -> (Arena, CardActionQueue) {
+    let mut arena = Arena::new(KingdomSet::FirstGame, 2);
+    let actions = arena.actions.take().unwrap();
+
+    (arena, actions)
+}
+
+pub(super) fn setup_arena() -> Arena {
+    Arena::new(KingdomSet::FirstGame, 2)
+}

--- a/dominion/src/dominion/arena/effect/throne_room.rs
+++ b/dominion/src/dominion/arena/effect/throne_room.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectOutput};
+use crate::dominion::arena::effect::{CardActionQueue, Effect, Outcome};
 use crate::dominion::types::{CardSpecifier, Error, Location, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "You may play an Action card from your hand twice.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -46,9 +46,9 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Effec
         let mut actions = CardActionQueue::from_card(cards[0]);
         actions.add_card(cards[0]);
 
-        Ok(EffectOutput::Actions(actions))
+        Ok(Outcome::Actions(actions))
     } else {
-        Ok(EffectOutput::None)
+        Ok(Outcome::None)
     }
 }
 
@@ -66,10 +66,7 @@ mod test {
 
         let cards = [];
 
-        assert_eq!(
-            func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::None)
-        );
+        assert_eq!(func(&mut arena, player_id, &cards), Ok(Outcome::None));
     }
 
     #[test]
@@ -112,7 +109,7 @@ mod test {
 
         assert_eq!(
             func(&mut arena, player_id, &cards),
-            Ok(EffectOutput::Actions({
+            Ok(Outcome::Actions({
                 let mut actions = CardActionQueue::new();
 
                 actions.add_card(cards[0]);

--- a/dominion/src/dominion/arena/effect/throne_room.rs
+++ b/dominion/src/dominion/arena/effect/throne_room.rs
@@ -1,11 +1,11 @@
-use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectResult};
-use crate::dominion::types::{CardSpecifier, Error, Location};
+use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectOutput};
+use crate::dominion::types::{CardSpecifier, Error, Location, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect =
     &Effect::Conditional(func, "You may play an Action card from your hand twice.");
 
-fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -42,8 +42,8 @@ fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult
         let mut actions = CardActionQueue::from_card(cards[0]);
         actions.add_card(cards[0]);
 
-        Ok(Some(actions))
+        Ok(EffectOutput::Actions(actions))
     } else {
-        Ok(None)
+        Ok(EffectOutput::None)
     }
 }

--- a/dominion/src/dominion/arena/effect/throne_room.rs
+++ b/dominion/src/dominion/arena/effect/throne_room.rs
@@ -1,0 +1,49 @@
+use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectResult};
+use crate::dominion::types::{CardSpecifier, Error, Location};
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect =
+    &Effect::Conditional(func, "You may play an Action card from your hand twice.");
+
+fn func(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> EffectResult {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    if player_id != arena.current_player_id {
+        return error;
+    }
+
+    let card_index;
+
+    if cards.is_empty() {
+        card_index = None;
+    } else if cards.len() == 1 {
+        match arena
+            .current_player()
+            .hand
+            .iter()
+            .position(|&hand_card| hand_card == cards[0])
+        {
+            Some(i) => card_index = Some(CardSpecifier::Index(i)),
+            None => return error,
+        };
+    } else {
+        return error;
+    }
+
+    if let Some(card_index) = card_index {
+        arena
+            .move_card(
+                Location::Hand { player_id },
+                Location::Play { player_id },
+                card_index,
+            )
+            .unwrap();
+
+        let mut actions = CardActionQueue::from_card(cards[0]);
+        actions.add_card(cards[0]);
+
+        Ok(Some(actions))
+    } else {
+        Ok(None)
+    }
+}

--- a/dominion/src/dominion/arena/effect/vassal.rs
+++ b/dominion/src/dominion/arena/effect/vassal.rs
@@ -1,0 +1,62 @@
+use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectOutput};
+use crate::dominion::types::{Error, Location, Result};
+use crate::dominion::{Arena, CardKind};
+
+pub(super) const EFFECT: &Effect = &Effect::Unconditional(discard);
+
+fn discard(arena: &mut Arena, _: usize, _: CardKind) -> EffectOutput {
+    let player = arena.current_player_mut();
+    match player.draw_card() {
+        Some(card) => {
+            let player_id = arena.current_player_id;
+
+            arena
+                .move_card(
+                    Location::Hand { player_id },
+                    Location::Discard { player_id },
+                    card,
+                )
+                .unwrap();
+
+            EffectOutput::Effect(PLAY_ACTION)
+        }
+        None => EffectOutput::None,
+    }
+}
+
+#[allow(clippy::non_ascii_literal)]
+const PLAY_ACTION: &Effect = &Effect::Conditional(
+    select,
+    "Discard the top card of your deck. If it’s an Action card, you may play it.",
+);
+
+fn select(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+    let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
+
+    if player_id != arena.current_player_id {
+        return error;
+    }
+
+    let play_card;
+
+    // Player chooses to play the discarded card with cards: [discarded_card].
+    // Player chooses not to play the discarded card with cards: [].
+    // Other inputs are treated as errors.
+    if cards.is_empty() {
+        play_card = false;
+    } else if cards.len() == 1 {
+        if cards[0] == *arena.current_player().discard_pile.last().unwrap() {
+            play_card = true;
+        } else {
+            return error;
+        }
+    } else {
+        return error;
+    }
+
+    if play_card {
+        Ok(EffectOutput::Actions(CardActionQueue::from_card(cards[0])))
+    } else {
+        Ok(EffectOutput::None)
+    }
+}

--- a/dominion/src/dominion/arena/effect/vassal.rs
+++ b/dominion/src/dominion/arena/effect/vassal.rs
@@ -1,10 +1,10 @@
-use crate::dominion::arena::effect::{CardActionQueue, Effect, EffectOutput};
+use crate::dominion::arena::effect::{CardActionQueue, Effect, Outcome};
 use crate::dominion::types::{Error, Location, Result};
 use crate::dominion::{Arena, CardKind};
 
 pub(super) const EFFECT: &Effect = &Effect::Unconditional(discard);
 
-fn discard(arena: &mut Arena, _: usize, _: CardKind) -> EffectOutput {
+fn discard(arena: &mut Arena, _: usize, _: CardKind) -> Outcome {
     let player = arena.current_player_mut();
     match player.draw_card() {
         Some(card) => {
@@ -18,9 +18,9 @@ fn discard(arena: &mut Arena, _: usize, _: CardKind) -> EffectOutput {
                 )
                 .unwrap();
 
-            EffectOutput::Effect(PLAY_ACTION)
+            Outcome::Effect(PLAY_ACTION)
         }
-        None => EffectOutput::None,
+        None => Outcome::None,
     }
 }
 
@@ -30,7 +30,7 @@ const PLAY_ACTION: &Effect = &Effect::Conditional(
     "Discard the top card of your deck. If it’s an Action card, you may play it.",
 );
 
-fn select(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<EffectOutput> {
+fn select(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Outcome> {
     let error = Err(Error::UnresolvedActionEffect(&EFFECT.description()));
 
     if player_id != arena.current_player_id {
@@ -55,8 +55,8 @@ fn select(arena: &mut Arena, player_id: usize, cards: &[CardKind]) -> Result<Eff
     }
 
     if play_card {
-        Ok(EffectOutput::Actions(CardActionQueue::from_card(cards[0])))
+        Ok(Outcome::Actions(CardActionQueue::from_card(cards[0])))
     } else {
-        Ok(EffectOutput::None)
+        Ok(Outcome::None)
     }
 }

--- a/dominion/src/dominion/arena/player.rs
+++ b/dominion/src/dominion/arena/player.rs
@@ -15,16 +15,16 @@ unsafe fn rng() -> &'static mut StdRng {
 }
 
 #[derive(Debug)]
-pub(crate) struct Player {
-    pub(crate) draw_pile: CardVec,
-    pub(crate) hand: CardVec,
-    pub(crate) play_zone: CardVec,
-    pub(crate) stage: CardVec,
-    pub(crate) discard_pile: CardVec,
+pub(super) struct Player {
+    pub(super) draw_pile: CardVec,
+    pub(super) hand: CardVec,
+    pub(super) play_zone: CardVec,
+    pub(super) stage: CardVec,
+    pub(super) discard_pile: CardVec,
 }
 
 impl Player {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         let mut draw_pile = vec![CardKind::Copper; 7];
         draw_pile.append(&mut vec![CardKind::Estate; 3]);
 
@@ -41,7 +41,7 @@ impl Player {
         p
     }
 
-    pub(crate) fn draw_card(&mut self) {
+    pub(super) fn draw_card(&mut self) {
         if self.draw_pile.is_empty() {
             std::mem::swap(&mut self.draw_pile, &mut self.discard_pile);
             self.shuffle_deck();
@@ -53,7 +53,7 @@ impl Player {
         }
     }
 
-    pub(crate) fn cleanup(&mut self) {
+    pub(super) fn cleanup(&mut self) {
         self.discard_pile.append(&mut self.play_zone);
         self.discard_pile.append(&mut self.hand);
 
@@ -62,7 +62,7 @@ impl Player {
         }
     }
 
-    pub(crate) fn in_deck(&self, card: CardKind) -> bool {
+    pub(super) fn in_deck(&self, card: CardKind) -> bool {
         self.draw_pile
             .iter()
             .chain(self.hand.iter())

--- a/dominion/src/dominion/arena/player.rs
+++ b/dominion/src/dominion/arena/player.rs
@@ -1,4 +1,4 @@
-use crate::dominion::types::CardVec;
+use crate::dominion::types::{CardSpecifier, CardVec};
 use crate::dominion::CardKind;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -41,7 +41,7 @@ impl Player {
         p
     }
 
-    pub(super) fn draw_card(&mut self) {
+    pub(super) fn draw_card(&mut self) -> Option<CardSpecifier> {
         if self.draw_pile.is_empty() {
             std::mem::swap(&mut self.draw_pile, &mut self.discard_pile);
             self.shuffle_deck();
@@ -49,7 +49,10 @@ impl Player {
 
         // We consider the top of the draw pile to be the end that is popped.
         if let Some(x) = self.draw_pile.pop() {
-            self.hand.push(x)
+            self.hand.push(x);
+            Some(CardSpecifier::Index(self.hand.len() - 1))
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
Allow CardAction to expand during resolution. An effect may append additional effects to the current CardAction.

Militia and Throne Room effects are moved into submodules. This PR also implements effects for additional cards as well as unit tests for all card effects.